### PR TITLE
Fixes rendering templates when included in wsgi

### DIFF
--- a/ceph-dash.py
+++ b/ceph-dash.py
@@ -73,7 +73,8 @@ class CephStatusView(MethodView):
 
 class CephAPI(Flask):
     def __init__(self, name):
-        Flask.__init__(self, name)
+        template_folder = os.path.join(os.path.dirname(__file__), 'templates')
+        Flask.__init__(self, name, template_folder=template_folder)
 
         status_view = CephStatusView.as_view('status')
         self.add_url_rule('/', view_func=status_view)


### PR DESCRIPTION
When included in the wsgi script, Flask needs to be told what directory to load templates out of.
