### PR TITLE
Make ceph-dash automatically do graphing by default

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -41,7 +41,7 @@ def InfluxInject(url='http://localhost/', host='localhost', port=8086):
     # we run this thread... so we will wait a small while
     time.sleep(2)
 
-    #print "DEBUG: Thread running..."
+    # print "DEBUG: Thread running..."
     status = CephClusterStatus(url)
     perfData = status.get_perf_data()
     status.InfluxDBInject(perfData, host, port)
@@ -74,11 +74,11 @@ else:
 
         if 'uri' in app.config['USER_CONFIG']['influxdb']:
             uriList = app.config['USER_CONFIG']['influxdb']['uri'].split('/')
-            hostname = uriList[2].split(':')[0]
-            portnum = uriList[2].split(':')[1]
+            host = uriList[2].split(':')[0]
+            port = uriList[2].split(':')[1]
 
             # run this in a seperate thread... will repeat until we close program
-            threading.Thread(target=InfluxInject, args=('http://localhost/', hostname, portnum)).start()
+            threading.Thread(target=InfluxInject, args=('http://localhost/', host, port)).start()
 
 # only load endpoint if user wants to use graphite
 if 'graphite' in app.config['USER_CONFIG']:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,12 +2,15 @@
 # -*- coding: utf-8 -*-
 
 import json
+import time
+import threading
 
 from os.path import dirname
 from os.path import join
 from flask import Flask
 
 from app.dashboard.views import DashboardResource
+from app.influxinjector import CephClusterStatus
 
 app = Flask(__name__)
 app.template_folder = join(dirname(__file__), 'templates')
@@ -32,6 +35,20 @@ class UserConfig(dict):
         configfile = join(dirname(dirname(__file__)), 'config.json')
         self.update(json.load(open(configfile), object_hook=self._string_decode_hook))
 
+
+def InfluxInject(url='http://localhost/', host='localhost', port=8086):
+    # the program isnt finished starting up yet the first time we run this thread... so wait 2 seconds
+    time.sleep(2)
+    
+    #print "DEBUG: Thread running..."
+    status = CephClusterStatus(url)
+    perfData = status.get_perf_data()
+    status.InfluxDBInject(perfData, host, port)
+    
+    # now lets fire up the thread again in 4 seconds... ad infinitum
+    threading.Timer(4, InfluxInject, [url, host, port]).start()
+
+
 app.config['USER_CONFIG'] = UserConfig()
 
 # only load influxdb endpoint if module is available
@@ -51,6 +68,14 @@ else:
     if 'influxdb' in app.config['USER_CONFIG']:
         from app.influx.views import InfluxResource
         app.register_blueprint(InfluxResource.as_blueprint())
+        
+        if 'uri' in app.config['USER_CONFIG']['influxdb']:
+            uriList = app.config['USER_CONFIG']['influxdb']['uri'].split('/')
+            hostname = uriList[2].split(':')[0]
+            portnum = uriList[2].split(':')[1]
+            
+            # run this in a seperate thread... will repeat until we close program
+            threading.Thread(target=InfluxInject, args=('http://localhost/', hostname, portnum)).start()
 
 # only load endpoint if user wants to use graphite
 if 'graphite' in app.config['USER_CONFIG']:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -78,7 +78,7 @@ else:
             port = uriList[2].split(':')[1]
 
             # run this in a seperate thread... will repeat until we close program
-            threading.Thread(target=InfluxInject, args=('http://localhost/', host, port)).start()
+            threading.Thread(target=InfluxInject, args=('http://'+host, host, port)).start()
 
 # only load endpoint if user wants to use graphite
 if 'graphite' in app.config['USER_CONFIG']:

--- a/app/influxinjector.py
+++ b/app/influxinjector.py
@@ -80,4 +80,4 @@ class CephClusterStatus(dict):
         client.create_retention_policy('standard', '1h', 3, default=True)
 
         client.write_points(data)
-        #print 'DEBUG: Wrote data to Influx'
+        # print 'DEBUG: Wrote data to Influx'

--- a/app/influxinjector.py
+++ b/app/influxinjector.py
@@ -2,11 +2,10 @@
 
 import sys
 import json
-import time
-import argparse
 from urllib2 import Request
 from urllib2 import urlopen
 from influxdb import InfluxDBClient
+
 
 class CephClusterStatus(dict):
     def __init__(self, url):
@@ -75,10 +74,10 @@ class CephClusterStatus(dict):
                 }
             }
         ]
-    
+
         client = InfluxDBClient(host, port, database=dbname)
         client.create_database(dbname)
         client.create_retention_policy('standard', '1h', 3, default=True)
-    
-        result = client.write_points(data)
+
+        client.write_points(data)
         #print 'DEBUG: Wrote data to Influx'

--- a/app/influxinjector.py
+++ b/app/influxinjector.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+
+import sys
+import json
+import time
+import argparse
+from urllib2 import Request
+from urllib2 import urlopen
+from influxdb import InfluxDBClient
+
+class CephClusterStatus(dict):
+    def __init__(self, url):
+        dict.__init__(self)
+        req = Request(url)
+        req.add_header('Content-Type', 'application/json')
+        try:
+            self.update(json.load(urlopen(req)))
+        except Exception as err:
+            print "UNKNOWN: %s" % (str(err), )
+            sys.exit(1)
+
+    def get_perf_data(self):
+        perf_values = {
+            'pgmap': ['bytes_used', 'bytes_total', 'bytes_avail', 'data_bytes', 'num_pgs', 'read_bytes_sec', 'write_bytes_sec', 'read_op_per_sec', 'write_op_per_sec'],
+        }
+
+        perfdata = dict()
+        for map_type, values in perf_values.iteritems():
+            for value in values:
+                perfdata[value] = self[map_type].get(value, 0)
+
+        return perfdata
+
+    def InfluxDBInject(self, perfData, host='localhost', port=8086):
+        dbname = 'cephstats'
+        data = [
+            {
+                "measurement": "ceph.cluster",
+                "tags": {
+                    "hostname": "ceph-mon-0",
+                    "type": "read_bytes_sec"
+                },
+                "fields": {
+                    "value": float(perfData['read_bytes_sec'])
+                }
+            },
+            {
+                "measurement": "ceph.cluster",
+                "tags": {
+                    "hostname": "ceph-mon-0",
+                    "type": "write_bytes_sec"
+                },
+                "fields": {
+                    "value": float(perfData['write_bytes_sec'])
+                }
+            },
+            {
+                "measurement": "ceph.cluster",
+                "tags": {
+                    "hostname": "ceph-mon-0",
+                    "type": "read_ops_sec"
+                },
+                "fields": {
+                    "value": float(perfData['read_op_per_sec'])
+                }
+            },
+            {
+                "measurement": "ceph.cluster",
+                "tags": {
+                    "hostname": "ceph-mon-0",
+                    "type": "write_ops_sec"
+                },
+                "fields": {
+                    "value": float(perfData['write_op_per_sec'])
+                }
+            }
+        ]
+    
+        client = InfluxDBClient(host, port, database=dbname)
+        client.create_database(dbname)
+        client.create_retention_policy('standard', '1h', 3, default=True)
+    
+        result = client.write_points(data)
+        #print 'DEBUG: Wrote data to Influx'
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--url', type=str, required=False, default='http://localhost',
+                        help='url for the ceph rados API')
+    parser.add_argument('--host', type=str, required=False, default='localhost',
+                        help='hostname of InfluxDB http API')
+    parser.add_argument('--port', type=int, required=False, default=8086,
+                        help='port of InfluxDB http API')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    
+    # Loop for as long as program is running...
+    while True:
+        status = CephClusterStatus(args.url)
+        perfData = status.get_perf_data()
+        status.InfluxDBInject(perfData, args.host, args.port)
+        #print "DEBUG: Now sleeping for 4 seconds..."
+        time.sleep(4)

--- a/app/influxinjector.py
+++ b/app/influxinjector.py
@@ -21,7 +21,7 @@ class CephClusterStatus(dict):
 
     def get_perf_data(self):
         perf_values = {
-            'pgmap': ['bytes_used', 'bytes_total', 'bytes_avail', 'data_bytes', 'num_pgs', 'read_bytes_sec', 'write_bytes_sec', 'read_op_per_sec', 'write_op_per_sec'],
+            'pgmap': ['read_bytes_sec', 'write_bytes_sec', 'read_op_per_sec', 'write_op_per_sec'],
         }
 
         perfdata = dict()
@@ -82,26 +82,3 @@ class CephClusterStatus(dict):
     
         result = client.write_points(data)
         #print 'DEBUG: Wrote data to Influx'
-
-
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--url', type=str, required=False, default='http://localhost',
-                        help='url for the ceph rados API')
-    parser.add_argument('--host', type=str, required=False, default='localhost',
-                        help='hostname of InfluxDB http API')
-    parser.add_argument('--port', type=int, required=False, default=8086,
-                        help='port of InfluxDB http API')
-    return parser.parse_args()
-
-
-if __name__ == '__main__':
-    args = parse_args()
-    
-    # Loop for as long as program is running...
-    while True:
-        status = CephClusterStatus(args.url)
-        perfData = status.get_perf_data()
-        status.InfluxDBInject(perfData, args.host, args.port)
-        #print "DEBUG: Now sleeping for 4 seconds..."
-        time.sleep(4)

--- a/ceph-dash.py
+++ b/ceph-dash.py
@@ -3,4 +3,4 @@
 
 from app import app
 
-app.run(host='0.0.0.0', debug=True)
+app.run(host='0.0.0.0', debug=True, port=80)

--- a/config.json
+++ b/config.json
@@ -1,3 +1,26 @@
 {
-    "ceph_config": "/etc/ceph/ceph.conf"
+    "ceph_config": "/etc/ceph/ceph.conf",
+    "influxdb": {
+        "uri": "influxdb://localhost:8086/cephstats",
+        "metrics": [
+            {
+                "queries" : [
+                    "SELECT mean(value) FROM \"ceph.cluster\" WHERE hostname =~ /ceph-mon-.*/ AND type = 'read_bytes_sec' AND time > now() - 15m GROUP BY time(10s);",
+                    "SELECT mean(value) FROM \"ceph.cluster\" WHERE hostname =~ /ceph-mon-.*/ AND type = 'write_bytes_sec' AND time > now() - 15m GROUP BY time(10s);"
+                ],
+                "labels": [ "Read Bytes", "Write Bytes" ],
+                "colors": [ "#00dd00", "#dd0000" ],
+                "mode": "byteRate"
+            },
+            {
+                "queries" : [
+                    "SELECT mean(value) FROM \"ceph.cluster\" WHERE hostname =~ /ceph-mon-.*/ AND type = 'read_ops_sec' AND time > now() - 15m GROUP BY time(10s);",
+                    "SELECT mean(value) FROM \"ceph.cluster\" WHERE hostname =~ /ceph-mon-.*/ AND type = 'write_ops_sec' AND time > now() - 15m GROUP BY time(10s);"
+                ],
+                "labels": [ "Read OPS", "Write OPS" ],
+                "colors": [ "#5bc0de", "#dddd00" ]
+            }
+        ]
+    }
 }
+


### PR DESCRIPTION
These changes should allow auto graphing on install and run of the program as long as user runs "apt-get influxdb python-influxdb" along with install of program.  Also the user must use the correct config file (the one with influxdb in it).

I did not make this backwards compatible with pre-jewel ceph (uses read/write_ops_per_sec not ops_per_sec) but I don't think that's an issue anymore as jewel has been our for over 4 months now, and the next release is around the corner.

Tested on Ubuntu 16.04 (Xenial)