### PR TITLE
Set jquery flot graph legend on top left instead of top right

### DIFF
--- a/app/static/js/ceph.dash.js
+++ b/app/static/js/ceph.dash.js
@@ -70,7 +70,8 @@ $(function () {
             timezone: "browser"
         },
         legend: {
-            show: true
+            show: true,
+            position: "nw"
         },
         grid: {
             hoverable: true,


### PR DESCRIPTION
The flot chart legend is at the top right of the graph at all times by default.  This can be annoying as sometimes you want to hover over the latest value spike on the graph to see how many MB or IOPS are read/written.  One will be unable to do so for a few minutes as the spike must pass completely under the graph first.

This one line change proposes simply to move it to the right side of the graph so it's not in the way.
