### PR TITLE
Add Options Parser to select alternative configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ You can find a blog entry regarding monitoring a Ceph cluster with ceph-dash on 
 
 Newest Feature
 --------------
+### Configuration File selection
+
+`ceph-dash.py` now takes a `-c` option that allows users to specify the location of the configuration file. This defaults to ./config.json but can be anywhere on the filesystem
+
 
 ### InfluxDB support
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,6 +8,7 @@ from os.path import join
 from flask import Flask
 
 from app.dashboard.views import DashboardResource
+from optparse import OptionParser
 
 app = Flask(__name__)
 app.template_folder = join(dirname(__file__), 'templates')
@@ -27,10 +28,18 @@ class UserConfig(dict):
             rv[key] = value
         return rv
 
+    def parse_options(self):
+        parser = OptionParser()
+        parser.add_option("-c", "--config", dest="conf",
+                          help="use configuration FILE",
+                          default=join(dirname(dirname(__file__)), 'config.json'))
+        (self.options, self.args) = parser.parse_args()
+
     def __init__(self):
         dict.__init__(self)
-        configfile = join(dirname(dirname(__file__)), 'config.json')
-        self.update(json.load(open(configfile), object_hook=self._string_decode_hook))
+        self.parse_options()
+        self.update(json.load(open(self.options.conf), object_hook=self._string_decode_hook))
+
 
 app.config['USER_CONFIG'] = UserConfig()
 


### PR DESCRIPTION
This allows the user to specify where the configuration file is located. Useful for the docker images that are out there as you can just append -c /path/to/config.json and it will just 'work'