### PR TITLE
Update entrypoint.sh to evaluate the KEYRING environment variable

### DIFF
--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -130,4 +130,4 @@ class DashboardResource(ApiResource):
             if request.mimetype == 'application/json':
                 return jsonify(cluster_status)
             else:
-                return render_template('status.html', data=cluster_status, config=self.config)
+                return render_template('status.html', data=cluster_status, config=self.config, title=request.args.get('title'))

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="utf-8">
-  <title>Ceph Dashboard</title>
+  <title>{% if title %}{{ title }}{% else %}Ceph Dashboard{% endif %}</title>
   <link href="{{ url_for('static', filename='css/bootstrap.min.slate.css') }}" rel="stylesheet">
   <link href="{{ url_for('static', filename='css/ceph.dash.css') }}" rel="stylesheet">
   <link rel="shortcut icon" href="{{ url_for('static', filename='img/favicon.ico') }}" />
@@ -11,7 +11,7 @@
 <body>
   <div class="container">
     <div class="well">
-      <h1>Ceph Dashboard</h1>
+      <h1>{% if title %}{{ title }}{% else %}Ceph Dashboard{% endif %}</h1>
       <p>
         <!--show warning icon if data is getting to old-->
         <span id="last_update" style="display:none;" class="glyphicon glyphicon-warning-sign icon-warn"></span>

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -12,7 +12,7 @@ echo "* NAME (keyring name to use)"
 echo "* ID (keyting id to use)"
 echo ""
 
-echo "${KEYRING}" > ${CEPHKEYRING}
+echo -e "${KEYRING}" > ${CEPHKEYRING}
 echo -e "[global]\nmon host = ${CEPHMONS}" > ${CEPHCONFIG}
 
 echo "# CEPH STATUS"


### PR DESCRIPTION
This allows easy configuration of the keyring when using software like Docker Compose since the keyring contains serveral lines. It can now be configured like:

```yaml
version: "2"
services:
  dash:
    build: ./src
    ports:
     - "5000:5000"
    environment:
     - CEPHMONS=10.254.240.21
     - KEYRING=[client.dash]\n  key = yada\n  caps mon = "allow r"
```