### PR TITLE
Added keyring file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-*.pyc
-.*.swp
-.idea
-venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 .*.swp
+.idea
+venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 MAINTAINER Christian Eichelmann "christian@crapworks.de"
 
-ENV CEPH_VERSION jewel
+ENV CEPH_VERSION mimic
 
 # Install Ceph
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -6,6 +6,7 @@ CEPHKEYRING="/etc/ceph/keyring"
 echo "# REQUIRED ENVIRONMENT VARIABLES"
 echo "* CEPHMONS (comma separated list of ceph monitor ip addresses)"
 echo "* KEYRING (full keyring to deploy in docker container)"
+echo "* Or KEYRING_FILE (path to file containing keyring to deploy in docker container)"
 echo ""
 echo "# OPTIONAL ENVIRONMENT VARIABLES"
 echo "* CONFIG (path to ceph-dash config file"
@@ -13,7 +14,6 @@ echo "* NAME (keyring name to use)"
 echo "* ID (keyting id to use)"
 echo ""
 
-echo "${KEYRING}" > ${CEPHKEYRING}
 echo -e "[global]\nmon host = ${CEPHMONS}" > ${CEPHCONFIG}
 
 echo "# CEPH STATUS"
@@ -22,6 +22,11 @@ ceph -s
 export CEPHDASH_CEPHCONFIG="${CEPHCONFIG}"
 export CEPHDASH_KEYRING="${CEPHKEYRING}"
 
+if [ -n "${KEYRING_FILE}" ]; then
+    cat ${KEYRING_FILE} > ${CEPHKEYRING}
+else
+    echo "${KEYRING}" > ${CEPHKEYRING}
+fi
 
 if [ -n "${CONFIG}" ]; then
     export CEPHDASH_CONFIGFILE="${CONFIG}"


### PR DESCRIPTION
Added the optional ability to use a secret or config which are both mounted in the container by default.
The following stack file could be used which uses secrets:

```
version: "3.6"
services:
  dashboard:
    image: crapworks/ceph-dash:latest
    deploy:
      replicas: 1
      restart_policy:
        condition: any
    environment:
      - "CEPHMONS=10.0.0.1,10.0.0.2,10.0.0.3"
      - 'KEYRING_FILE=/run/secrets/ceph-admin-keyring'
    secrets:
      - ceph-admin-keyring

secrets:
  ceph-admin-keyring:
    external: true
```

Or using configs:

```
version: "3.6"
services:
  dashboard:
    image: crapworks/ceph-dash:latest
    deploy:
      replicas: 1
      restart_policy:
        condition: any
    environment:
      - "CEPHMONS=10.0.0.1,10.0.0.2,10.0.0.3"
      - 'KEYRING_FILE=/ceph-admin-keyring'
    configs:
      - ceph-admin-keyring

configs:
  ceph-admin-keyring:
    external: true
```

If **KEYRING_FILE** is not found, **KEYRING** is required.

This should solve #60 