### PR TITLE
Ceph 15.2.5

### DIFF
--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -119,6 +119,8 @@ class DashboardResource(ApiResource):
             if 'osdmap' not in cluster_status['osdmap']:
                 # osdmap has been converted to depth-1 dict
                 cluster_status['osdmap']['osdmap'] = cluster_status['osdmap'].copy()
+                monitor_status = CephClusterCommand(cluster, prefix='quorum_status', format='json')
+                cluster_status['monmap'] = monitor_status['monmap']
             total_osds = cluster_status['osdmap']['osdmap']['num_osds']
             in_osds = cluster_status['osdmap']['osdmap']['num_up_osds']
             up_osds = cluster_status['osdmap']['osdmap']['num_in_osds']

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -2,9 +2,6 @@
 # -*- coding: UTF-8 -*-
 
 import json
-import subprocess as sp
-
-from packaging import version
 
 from flask import request
 from flask import render_template
@@ -113,13 +110,12 @@ class DashboardResource(ApiResource):
 
     def get(self):
         with Rados(**self.clusterprop) as cluster:
-            ceph_version = version.parse(sp.check_output(["ceph", "-v"]).split()[2])
             cluster_status = CephClusterCommand(cluster, prefix='status', format='json')
             if 'err' in cluster_status:
                 abort(500, cluster_status['err'])
 
             # ceph >= 15.2.5
-            if ceph_version >= version.parse('15.2.5'):
+            if 'osdmap' not in cluster_status['osdmap']:
                 # osdmap has been converted to depth-1 dict
                 cluster_status['osdmap']['osdmap'] = cluster_status['osdmap'].copy()
                 monitor_status = CephClusterCommand(cluster, prefix='quorum_status', format='json')

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -115,12 +115,13 @@ class DashboardResource(ApiResource):
                 abort(500, cluster_status['err'])
 
             # check for unhealthy osds and get additional osd infos from cluster
-            # osdmap has been converted to depth-1 dict
-            total_osds = cluster_status['osdmap']['num_osds']
-            in_osds = cluster_status['osdmap']['num_up_osds']
-            up_osds = cluster_status['osdmap']['num_in_osds']
-            # JS still requires depth-2 osdmap
-            cluster_status['osdmap']['osdmap'] = cluster_status['osdmap'].copy()
+            # ceph >= 15.2.5
+            if 'osdmap' not in cluster_status['osdmap']:
+                # osdmap has been converted to depth-1 dict
+                cluster_status['osdmap']['osdmap'] = cluster_status['osdmap'].copy()
+            total_osds = cluster_status['osdmap']['osdmap']['num_osds']
+            in_osds = cluster_status['osdmap']['osdmap']['num_up_osds']
+            up_osds = cluster_status['osdmap']['osdmap']['num_in_osds']
 
             if up_osds < total_osds or in_osds < total_osds:
                 osd_status = CephClusterCommand(cluster, prefix='osd tree', format='json')

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -115,9 +115,12 @@ class DashboardResource(ApiResource):
                 abort(500, cluster_status['err'])
 
             # check for unhealthy osds and get additional osd infos from cluster
-            total_osds = cluster_status['osdmap']['osdmap']['num_osds']
-            in_osds = cluster_status['osdmap']['osdmap']['num_up_osds']
-            up_osds = cluster_status['osdmap']['osdmap']['num_in_osds']
+            # osdmap has been converted to depth-1 dict
+            total_osds = cluster_status['osdmap']['num_osds']
+            in_osds = cluster_status['osdmap']['num_up_osds']
+            up_osds = cluster_status['osdmap']['num_in_osds']
+            # JS still requires depth-2 osdmap
+            cluster_status['osdmap']['osdmap'] = cluster_status['osdmap'].copy()
 
             if up_osds < total_osds or in_osds < total_osds:
                 osd_status = CephClusterCommand(cluster, prefix='osd tree', format='json')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 flask>=0.10
 python-cephlibs
-packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask>=0.10
 python-cephlibs
+packaging


### PR DESCRIPTION
Fixes missing sub-dictionaries introduced in recent versions of Ceph (octopus).
I tried to be the most retro-compatible possible.
Requirement added: packaging, for Ceph versions comparison.