### PR TITLE
add python3 support and fix Rados.mon_command call for ceph pacific

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -75,12 +75,18 @@ class UserConfig(dict):
 
     def _string_decode_hook(self, data):
         rv = {}
-        for key, value in data.iteritems():
+        for key, value in data.items():
+          try:
             if isinstance(key, unicode):
                 key = key.encode('utf-8')
             if isinstance(value, unicode):
                 value = value.encode('utf-8')
-            rv[key] = value
+          # unicode does not exist if python3 is used
+          # ignore and don't do encoding, it is not
+          # needed in python3
+          except NameError:
+            pass
+          rv[key] = value
         return rv
 
     def __init__(self):

--- a/app/base.py
+++ b/app/base.py
@@ -11,7 +11,7 @@ class ApiResource(MethodView):
     def as_blueprint(cls, name=None):
         name = name or cls.endpoint
         bp = Blueprint(name, cls.__module__, url_prefix=cls.url_prefix)
-        for endpoint, options in cls.url_rules.iteritems():
+        for endpoint, options in cls.url_rules.items():
             url_rule = options.get('rule', '')
             defaults = options.get('defaults', {})
             bp.add_url_rule(url_rule, defaults=defaults, view_func=cls.as_view(endpoint))

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -44,7 +44,7 @@ class CephClusterCommand(dict):
 
     def __init__(self, cluster, **kwargs):
         dict.__init__(self)
-        ret, buf, err = cluster.mon_command(json.dumps(kwargs), '', timeout=5)
+        ret, buf, err = cluster.mon_command(json.dumps(kwargs), b'', timeout=5)
         if ret != 0:
             self['err'] = err
         else:

--- a/app/graphite/views.py
+++ b/app/graphite/views.py
@@ -7,7 +7,12 @@ import json
 from flask import jsonify
 from flask import current_app
 
-from urllib2 import urlopen
+# import urlopen from urllib.request / Python3
+# and fallback to urlopen from urllib2 / Python2
+try:
+  from urllib.request import urlopen
+except ImportError:
+  from urllib2 import urlopen
 
 from app.base import ApiResource
 


### PR DESCRIPTION
these commits:
- **add support for python3** Resolves #66 

        
        * mostly using 2to3
        * added try / except to import urlopen
          to support python2 and python3
        * add try / except to _string_decode_hook
          unicode no longer exists in python3 (the code probably never worked with utf-8 characters
          in python2 anyway but i kept the old behavior, this might not be the best way to deal with it, ideas?)
        

- **fix Rados.mon_command() for ceph pacific** resolves #67 

        ceph pacific expects the inbuf argument to be passed as bytes and not str
        this should work fine for older versions too
        see:
        https://bugs.launchpad.net/cinder/+bug/1913449
        https://github.com/ceph/ceph/commit/51a2a72215ac93836ccc37733607b8e97d808e10